### PR TITLE
feature/use-validate-hook-in-this-repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,12 @@ repos:
   hooks:
   - id: check-toml
   - id: no-commit-to-branch
+
+- repo: local
+  hooks:
+  -   id: validate-security-scan
+      name: validate-security-scan
+      entry: python3 -m hooks.validate_security_scan --verbose
+      language: python
+      stages: [commit-msg]
+      verbose: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ Activate it using `source .venv/bin/activate`
 Run `pip install -e .`
 Run `pip install -r requirements-dev.txt`
 
-## Usage in your project
+## Testing hooks
+
+Using the pre-commit `try-repo` command, it is possible to test hooks locally before release a new version.
+
+### Testing commit-msg hooks
+
+The commit-msg hook stage is passes a single parameter, which is the name of the file containing the current commit message. To test this locally, you need a file created with the contents being the commit message you want to test. For convenience, a test file has been added to tests/data that can be used with the below command
+`pre-commit try-repo ./ validate-security-scan --hook-stage commit-msg --commit-msg-filename tests/data/COMMIT_MSG.txt --verbose --all-files -v`
+
+# Usage in your project
 
 [See installation instructions](docs/Installation.md)

--- a/tests/data/COMMIT_MSG.txt
+++ b/tests/data/COMMIT_MSG.txt
@@ -1,0 +1,3 @@
+Hello world
+
+Signed-off-by: DBT pre-commit check


### PR DESCRIPTION
Use the validate security scan hook in this repo as a local hook, so the Signed off headers are added to commits