### PR TITLE
feature/GSF-36-add-docker-tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,3 +28,4 @@ test_keys/
 .DS_Store
 .vscode/
 .github/
+.pre-commit-config.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,28 @@ jobs:
 
       - name: Run tests
         run: pytest .
+
+  test-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: dbt-hooks:verification-testing
+          target: testing
+
+      - name: Test run security scan
+        run: docker run dbt-hooks:verification-testing --hook-id=run-security-scan --verbose
+
+      - name: Test validate security scan
+        run: |
+          echo 'Test commit message' >> COMMIT.txt
+          docker run --mount type=bind,source=./COMMIT.txt,target=/app/COMMIT.txt dbt-hooks:verification-testing --hook-id=validate-security-scan --verbose COMMIT.txt

--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ __marimo__/
 test_keys/
 
 .DS_Store
+tests/EXAMPLE_COMMIT_MSG.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,6 @@ repos:
 
 - repo: local
   hooks:
-  -   id: validate-security-scan
-      name: validate-security-scan
-      entry: python3 -m src.cli --hook-id=validate-security-scan --verbose
-      language: python
-      additional_dependencies: [pyyaml, requests]
-      stages: [commit-msg]
-      verbose: true
-  
   -   id: run-security-scan
       name: run-security-scan
       entry: python3 -m src.cli --hook-id=run-security-scan --verbose
@@ -28,3 +20,11 @@ repos:
       stages: [pre-commit]
       verbose: true
       require_serial: true
+
+  -   id: validate-security-scan
+      name: validate-security-scan
+      entry: python3 -m src.cli --hook-id=validate-security-scan --verbose
+      language: python
+      additional_dependencies: [pyyaml, requests]
+      stages: [commit-msg]
+      verbose: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,3 @@
--   id: validate-security-scan
-    name: Validate the security scan hook
-    description: Validate the hook that runs the security scans has run, and add a signed-off git trailer if security scans have passed
-    language: docker_image
-    entry: ghcr.io/uktrade/dbt-hooks:development --hook-id=validate-security-scan
-    stages: [commit-msg]
-
 -   id: run-security-scan
     name: Run a security scan
     description: Run a security scan against the files in this commit
@@ -12,3 +5,10 @@
     entry: ghcr.io/uktrade/dbt-hooks:development --hook-id=run-security-scan
     stages: [pre-commit]
     require_serial: true # This avoids the pre-commit spliting the list of changed files into batches of 4, and calling the pre-commit hook multiple times
+
+-   id: validate-security-scan
+    name: Validate the security scan hook
+    description: Validate the hook that runs the security scans has run, and add a signed-off git trailer if security scans have passed
+    language: docker_image
+    entry: ghcr.io/uktrade/dbt-hooks:development --hook-id=validate-security-scan
+    stages: [commit-msg]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine
+FROM python:3.13-alpine AS base
 
 ENV PYTHONUNBUFFERED=1
 ENV PIP_NO_CACHE_DIR=1
@@ -15,3 +15,9 @@ COPY src /app/src
 RUN pip install .
 
 ENTRYPOINT ["hooks-cli"]
+
+FROM base AS testing
+COPY example.pre-commit-config.yaml /app/.pre-commit-config.yaml
+
+FROM testing AS local-testing
+RUN echo 'Hello world' >> /app/EXAMPLE_COMMIT_MSG.txt

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,20 @@ test-coverage:
 build-docker:
 	docker build . -t dbt-hooks:dev
 
-validate-hook:
-	hooks-cli --hook-id=validate-security-scan --verbose
+build-docker-local-testing:
+	docker build . -t dbt-hooks:local-testing --target local-testing
 
-run-hook:
+validate-hook-python:
+	echo 'Hello world' >> ./tests/EXAMPLE_COMMIT_MSG.txt && hooks-cli --hook-id=validate-security-scan --verbose ./tests/EXAMPLE_COMMIT_MSG.txt
+
+validate-hook-docker:
+	# the EXAMPLE_COMMIT_MSG.txt file is created inside the Dockerfile using the local-testing target
+	make build-docker-local-testing
+	docker run --rm dbt-hooks:local-testing --hook-id validate-security-scan --verbose EXAMPLE_COMMIT_MSG.txt
+
+run-hook-python:
 	hooks-cli --hook-id=run-security-scan --verbose
+
+run-hook-docker:
+	make build-docker-local-testing
+	docker run --rm dbt-hooks:local-testing --hook-id run-security-scan --verbose EXAMPLE_COMMIT_MSG.txt

--- a/README.md
+++ b/README.md
@@ -6,9 +6,28 @@ Run `pip install --upgrade pip`
 Run `pip install -e .`
 Run `pip install . --group dev`
 
-## Testing hooks
+# Testing
 
-Using the pre-commit `try-repo` command, it is possible to test hooks locally before release a new version.
+## Testing hooks locally
+
+While developing hooks, there are multiple ways of verifying these on your local machine before raising a PR:
+
+### Running the hook command using python
+
+As the hooks are written using python, it is possible to call the python file contain the hook directly passing the same arguments the pre-commit library would pass. There is a make command `validate-hook-python` that will run this in verbose mode and write debug messages to the terminal.
+
+For the run-security-scan hook, the command would look like this, where `--files` can be one or more filenames to scan: `python3 -m src.cli --hook-id=run-security-scan --verbose --files Dockerfile`
+
+### Running the hooks using docker
+
+As the hooks are run using a docker image within other repositories, it is a good idea to test your changes by building and running them using a local docker image.
+There is a make command for each of the hooks, that will build and run that hook for you with the correct arguments.
+For the run hook it is `run-hook-docker`.
+For the validate hook it is `validate-hook-docker`.
+
+## Testing hooks from an external repository
+
+Using the pre-commit `try-repo` command, it is possible to test hooks locally in an external repo before releasing a new version.
 
 ### Testing pre-commit hooks
 
@@ -19,6 +38,19 @@ The pre-commit hooks receive a list of filenames that have changed in the commit
 
 The commit-msg hook stage is passes a single parameter, which is the name of the file containing the current commit message. To test this locally, you need a file created with the contents being the commit message you want to test. For convenience, a test file has been added to tests/data that can be used with the below command
 `pre-commit try-repo ./ validate-security-scan --hook-stage commit-msg --commit-msg-filename tests/test_data/COMMIT_MSG.txt --verbose --all-files -v`
+
+# Releasing
+
+There is a github action that can be run to release a new version of the hooks. To create a new release:
+
+1. Go to https://github.com/uktrade/dbt-hooks/tags and find the latest tag
+1. Go to https://github.com/uktrade/dbt-hooks/actions/workflows/release.yml and click the `Run workflow` button. This repository uses semantic versioning, so in the `Version to release` input add the new version
+1. Press the `Run workflow` button, wait for the action to finish
+
+You will now have:
+
+- A github release using the new version, set to the be the latest version
+- A docker image build and deployed to TBC
 
 # Usage in your project
 

--- a/example.pre-commit-config.yaml
+++ b/example.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 repos:
   - repo: https://github.com/uktrade/dbt-hooks
-    rev: main # This should be the latest version, see docs for ensuring this is up-to-date
+    rev: main # This should be the latest github released version, see docs for ensuring this is up-to-date
     hooks:
       - id: validate-security-scan
-        stages: [commit-msg]
         verbose: true # This is helpful for debugging initial setup, it can be removed when the hooks are verified as working in your repositoty
         args: [-v] # This is helpful for debugging the hook logic, the output is shown in the git output
+      - id: run-security-scan
+        verbose: true
+        args: [--verbose]

--- a/src/hooks_base.py
+++ b/src/hooks_base.py
@@ -30,7 +30,7 @@ class Hook(ABC):
 
     def validate_hook_settings(self) -> bool:
         if self._skip_check():
-            logger.debug("This hook is being run inside the dbt-hooks repo, it can be ignored")
+            logger.debug("This hook is being run inside the dbt-hooks repo, the validate hooks settings can be ignored")
             return True
 
         if not Path(PRE_COMMIT_FILE).exists():


### PR DESCRIPTION
Build and test docker image inside a github action, to ensure when this docker image is used by other repositories there are no easy to catch errors present