### PR TITLE
bugfix/GSF-37-Bugfix-Commit-messages-with-multi-lines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   hooks:
     - id: ruff-check
     - id: ruff-format
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0  
   hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: Run a security scan
     description: Run a security scan against the files in this commit
     language: docker_image
-    entry: ghcr.io/uktrade/dbt-hooks:development --hook-id=run-security-scan
+    entry: 650575079077.dkr.ecr.eu-west-2.amazonaws.com/dbt-hooks:latest --hook-id=run-security-scan
     stages: [pre-commit]
     require_serial: true # This avoids the pre-commit spliting the list of changed files into batches of 4, and calling the pre-commit hook multiple times
 
@@ -10,5 +10,5 @@
     name: Validate the security scan hook
     description: Validate the hook that runs the security scans has run, and add a signed-off git trailer if security scans have passed
     language: docker_image
-    entry: ghcr.io/uktrade/dbt-hooks:development --hook-id=validate-security-scan
+    entry: 650575079077.dkr.ecr.eu-west-2.amazonaws.com/dbt-hooks:latest --hook-id=validate-security-scan
     stages: [commit-msg]

--- a/tests/hooks/test_validate_security_scan.py
+++ b/tests/hooks/test_validate_security_scan.py
@@ -117,14 +117,26 @@ class TestValidateSecurityScan:
             tf.seek(0)
             assert ValidateSecurityScan(files=[tf.name]).run() is True
 
-            assert tf.read().decode("UTF-8") == f"A helpful commit message\n\n{src.config.SIGNED_OFF_BY_TRAILER}"
+            assert tf.read().decode("UTF-8") == f"A helpful commit message\n{src.config.SIGNED_OFF_BY_TRAILER}"
+
+    def test_run_with_file_with_multiline_message_has_signed_off_by_trailer_added(self):
+        with (
+            tempfile.NamedTemporaryFile() as tf,
+            patch.object(ValidateSecurityScan, "validate_hook_settings", return_value=True),
+        ):
+            tf.writelines(line + b"\n" for line in [b"A", b"helpful", b"commit", b" message"])
+            tf.seek(0)
+
+            assert ValidateSecurityScan(files=[tf.name]).run() is True
+
+            assert tf.read().decode("UTF-8") == f"A\nhelpful\ncommit\n message\n\n{src.config.SIGNED_OFF_BY_TRAILER}"
 
     def test_run_with_file_with_existing_signed_off_header_is_replaced(self):
         with (
             tempfile.NamedTemporaryFile() as tf,
             patch.object(ValidateSecurityScan, "validate_hook_settings", return_value=True),
         ):
-            tf.write(b"A helpful commit message\n\Signed-off-by: SOMETHING ELSE")
+            tf.write(b"A helpful commit message\nSigned-off-by: SOMETHING ELSE")
             tf.seek(0)
 
             assert ValidateSecurityScan(files=[tf.name]).run() is True

--- a/tests/test_data/COMMIT_MSG.txt
+++ b/tests/test_data/COMMIT_MSG.txt
@@ -1,3 +1,2 @@
 Hello world
-
-Signed-off-by: DBT pre-commit check
+Hello world 2


### PR DESCRIPTION
Handle the scenario where the commit message can have multiple lines