### PR TITLE
feature/test-dockerfile-instead-of-docker-image

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,14 +1,14 @@
 -   id: run-security-scan
     name: Run a security scan
     description: Run a security scan against the files in this commit
-    language: docker_image
-    entry: 650575079077.dkr.ecr.eu-west-2.amazonaws.com/github-standards-hooks:latest run_scan
+    language: docker
+    entry: hooks-cli run_scan
     stages: [pre-commit]
     require_serial: true # This avoids the pre-commit spliting the list of changed files into batches of 4, and calling the pre-commit hook multiple times
 
 -   id: validate-security-scan
     name: Validate the security scan hook
     description: Validate the hook that runs the security scans has run, and add a signed-off git trailer if security scans have passed
-    language: docker_image
-    entry: 650575079077.dkr.ecr.eu-west-2.amazonaws.com/github-standards-hooks:latest validate_scan
+    language: docker
+    entry: hooks-cli validate_scan
     stages: [commit-msg]


### PR DESCRIPTION
Switch to remove the hook as a pre-built docker image that is pulled from ECR and ran on the dev laptop, to using a dockerfile that will run the docker build command on the dev laptop.

This isn't ideal, as each dev will need to build the image locally, but it should get around the issue with the ECR image requiring authentication