### PR TITLE
feature/add-help-text-to-commit-message-check-action

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -9,10 +9,12 @@ jobs:
   pre-commit-check:
     env:
       SIGNED_OFF_MESSAGE: "Signed-off-by: DBT pre-commit check"
+      FAILURE_MESSAGE: "Your PR has commits that are missing the Signed-off-by trailer. This is likely due to the pre-commit hook not being configured on your local machince. For help in setting up the pre-commit hooks, follow the instructions at https://github.com/uktrade/github-standards/blob/main/docs/Installation.md"
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout current repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -20,6 +22,37 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check if pre-commit hook ran before push
+        id: pre-commit-check
         run: |
           git log ${{ github.event.pull_request.head.sha }} --format=%B -1 | git interpret-trailers --parse | grep '${{ env.SIGNED_OFF_MESSAGE }}'
-        continue-on-error: true # This needs to be removed after testing, as a failure to find the header should fail the build
+        continue-on-error: true # This is only here while we are testing, it should be removed during the go live process so PRs cannot be merged
+
+      - name: Find failure comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: ${{ env.FAILURE_MESSAGE }}
+        continue-on-error: true # Here incase this step breaks, which would break all org PRs. Don't remove
+
+      - name: Create or update failure comment
+        if: failure() || steps.pre-commit-check.outcome == 'failure'
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ env.FAILURE_MESSAGE }}
+          edit-mode: replace
+        continue-on-error: true # Here incase this step breaks, which would break all org PRs
+
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        name: Remove pre-commit comment
+        if: success() && steps.pre-commit-check.outcome == 'success' && steps.find-comment.outputs.comment-id
+        with:
+          script: |
+            github.rest.issues.deleteComment({
+              comment_id: ${{ steps.find-comment.outputs.comment-id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+        continue-on-error: true # Here incase this step breaks, which would break all org PRs


### PR DESCRIPTION
<!---
THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
--->

## What
Add a step to the pre-commit check action to inform user why their action failed. This will appear as a comment on the PR, see the bottom of this page for an example. When they fix the issue by adding a commit with the correct trailer, the message will be removed
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why
When the pre-commit check fails, a user needs to know they are missing the pre-commit local hook. They can find out the reason if they look at the logs, but it would be easier to tell them on the PR
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [ ] I have tested locally
- [ ] Testing not required

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
