### PR TITLE
feature/build-arm-docker-image

### DIFF
--- a/.github/workflows/build-and-push-to-ecr.yml
+++ b/.github/workflows/build-and-push-to-ecr.yml
@@ -25,18 +25,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: main
-
-      - name: Validate Dockerfile with dockerfile-validator
-        if: ${{ hashFiles('Dockerfile') != '' }}
-        uses: ghe-actions/dockerfile-validator@12ed0b63096a928bd3db6fc47d482b6f462ab9c6
-        with:
-          dockerfile: "Dockerfile"
-          lint: "dockerlint"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@555a8e9ce6a5e366d51c2da432d183bddad135f6
         with:
@@ -66,12 +54,21 @@ jobs:
           read -ra tags <<<${{ inputs.image_tag }}
           for tag in "${tags[@]}"
           do
-              TAG_COMMAND="$TAG_COMMAND -t ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repo }}:$tag"
+              TAG_COMMAND="$TAG_COMMAND ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repo }}:$tag"
           done
           echo "tags=$TAG_COMMAND" >> $GITHUB_OUTPUT
 
-      - name: Build, tag, and push the image to Amazon ECR
-        id: build-and-push
-        run: |
-          docker build ${{ steps.create-docker-tags.outputs.tags }} .
-          docker image push --all-tags ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repo }}
+      - name: Set up Docker Buildx
+        id: setup
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push Docker image to Amazon ECR
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          platforms: ${{ steps.setup.outputs.platforms }}
+          push: true
+          target: release
+          tags: ${{ steps.create-docker-tags.outputs.tags }}
+          provenance: false # This is here to avoid ecr having an image for unknown/unknown


### PR DESCRIPTION
Use the `docker/build-push-action` to handle the building and pushing of the docker images to AWS ECR. Using this action makes targeting both `linux/amd64` and `linux/arm64` as simple as adding a config value instead of writing a custom docker script.

Removed the `actions/checkout` step from the workflow, as the `docker/build-push-action` does this internally