### PR TITLE
bugfix/proxy-permission-failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,10 @@ jobs:
         run: uv run pytest
 
   run-docker-verification:
+    env:
+      # These are set in the Dockerfile and used here as a workaround for proxy.py
+      USER_ID: 98657
+      GROUP_ID: 87485
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,9 +52,11 @@ jobs:
           target: testing
 
       - name: Test run security scan
-        run: docker run github-standards-hooks:verification-testing run_scan --verbose README.md
+        run: docker run --user ${{env.USER_ID}}:${{env.GROUP_ID}} -v .:/source:rw,Z --workdir /source github-standards-hooks:verification-testing run_scan --verbose README.md
 
       - name: Test validate security scan
         run: |
           echo 'Test commit message' >> COMMIT.txt
-          docker run --mount type=bind,source=./COMMIT.txt,target=/app/COMMIT.txt github-standards-hooks:verification-testing validate_scan --verbose COMMIT.txt
+          ls -la
+          id
+          docker run --user $(id -u):$(id -g) -v .:/source:rw,Z --workdir /source github-standards-hooks:verification-testing validate_scan --verbose COMMIT.txt

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,8 @@
     name: Run a security scan
     description: Run a security scan against the files in this commit
     language: docker_image
-    entry: ghcr.io/uktrade/github-standards:latest run_scan
+    # Due to the way proxy.py works, we have to specify the uuid and gid as a user arg to docker run
+    entry: --user 98657:87485 ghcr.io/uktrade/github-standards:latest run_scan
     stages: [pre-commit]
     require_serial: true # This avoids the pre-commit spliting the list of changed files into batches of 4, and calling the pre-commit hook multiple times
 
@@ -10,5 +11,6 @@
     name: Validate the security scan hook
     description: Validate the hook that runs the security scans has run, and add a signed-off git trailer if security scans have passed
     language: docker_image
-    entry: ghcr.io/uktrade/github-standards:latest validate_scan
+    # Due to the way proxy.py works, we have to specify the uuid and gid as a user arg to docker run
+    entry: --user 98657:87485 ghcr.io/uktrade/github-standards:latest validate_scan
     stages: [commit-msg]

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,12 @@ validate-hook-python:
 validate-hook-docker:
 	# the EXAMPLE_COMMIT_MSG.txt file is created inside the Dockerfile using the testing target
 	make build-docker-testing
-	docker run --rm github-standards-hooks:testing validate_scan --verbose EXAMPLE_COMMIT_MSG.txt
+	echo 'Hello world commit message' > tests/EXAMPLE_COMMIT_MSG.txt
+	docker run --rm -v .:/src:rw,Z --workdir /src github-standards-hooks:testing validate_scan --verbose tests/EXAMPLE_COMMIT_MSG.txt
 
 run-hook-python:
 	hooks-cli run_scan --verbose ./src
 
 run-hook-docker:
 	make build-docker-testing
-	docker run --rm github-standards-hooks:testing run_scan --verbose /app/src
+	docker run --rm -v .:/src:rw,Z --workdir /src github-standards-hooks:testing run_scan --verbose src/hooks/cli.py

--- a/src/hooks/trufflehog/vendors.py
+++ b/src/hooks/trufflehog/vendors.py
@@ -73,6 +73,7 @@ class AWS(AllowedTrufflehogVendor):
     def endpoints(self) -> list[str]:
         return [
             "sts.us-east-1.amazonaws.com",
+            "sns.us-east-1.amazonaws.com",
         ]
 
 

--- a/tests/unit/trufflehog/test_vendors.py
+++ b/tests/unit/trufflehog/test_vendors.py
@@ -30,6 +30,7 @@ class TestAllowedTrufflehogVendor:
         assert AllowedTrufflehogVendor.all_endpoints() == [
             "api.datadoghq.com",
             "sts.us-east-1.amazonaws.com",
+            "sns.us-east-1.amazonaws.com",
             "circleci.com/api/v2/me",
             "api.github.com",
             "gitlab.com",
@@ -48,7 +49,10 @@ class TestDatadog(BaseVendorTests):
 class TestAWS(BaseVendorTests):
     cls = AWS
     expected_code = "AWS"
-    expected_endpoints = ["sts.us-east-1.amazonaws.com"]
+    expected_endpoints = [
+        "sts.us-east-1.amazonaws.com",
+        "sns.us-east-1.amazonaws.com",
+    ]
 
 
 class TestCircleCI(BaseVendorTests):


### PR DESCRIPTION
- Add a custom user to run the docker image with. This is needed due to the way the proxy.py package creates local cache files
- Add an extra AWS endpoint for using in verification