### PR TITLE
bugfix/trufflehog-in-github-action-not-scanning

### DIFF
--- a/.github/workflows/org.common-ci.yml
+++ b/.github/workflows/org.common-ci.yml
@@ -67,6 +67,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          fetch-depth: 0
+
       - name: Secret Scanning using our docker image
         run: |
           docker run -e FORCE_HOOK_CHECKS=0 --rm -v .:/repo_files -w /repo_files \


### PR DESCRIPTION
Pull all repo branches on secret scanning to ensure we have all commits from the current branch up until main