### PR TITLE
feature/dont-run-personal-data-scan-in-docker-image

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,22 +2,21 @@
     name: Run a security scan
     description: Run a security scan against the files in this commit
     language: docker_image
-    entry: ghcr.io/uktrade/github-standards:v0.0.18 run_scan
+    entry: ghcr.io/uktrade/github-standards:v0.0.19 run_scan
     stages: [pre-commit]
     require_serial: true # This avoids the pre-commit spliting the list of changed files into batches of 4, and calling the pre-commit hook multiple times
 
 -   id: run-personal-data-scan
     name: Run a personal data scan
     description: Run a security scan against the files in this commit
-    language: docker_image
-    entry: ghcr.io/uktrade/github-standards:v0.0.18 run_personal_data_scan
+    language: system
+    entry: bash -c 'echo "Placeholder for personal data scan ghcr.io/uktrade/github-standards:v0.0.19" && exit 0'
     stages: [pre-commit]
-    require_serial: true # This avoids the pre-commit spliting the list of changed files into batches of 4, and calling the pre-commit hook multiple times
 
 -   id: validate-security-scan
     name: Validate the security scan hook
     description: Validate the hook that runs the security scans has run, and add a signed-off git trailer if security scans have passed
     language: docker_image
-    entry: ghcr.io/uktrade/github-standards:v0.0.18 validate_scan
+    entry: ghcr.io/uktrade/github-standards:v0.0.19 validate_scan
     stages: [commit-msg]
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ There is a github workflow that will automatically create a new docker tag, and 
 
 1. Open the `pyproject.toml` file, and update the `version` tag to a new value. We use semantic versioning, see [this article](https://www.geeksforgeeks.org/software-engineering/introduction-semantic-versioning/) for help determining what the new version value should be
 2. Make sure the `entry` tag for each of the hooks in the `.pre-commit-hooks.yaml` match this new version. There is an automated test that fails a PR if these values don't match
-3. Open a PR into main. Once approved, merging will trigger a new release
+3. Run `uv sync` to ensure the package is set to the correct version
+4. Open a PR into main. Once approved, merging will trigger a new release
 
 You will now have:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["pre-commit", "dbt", "hooks", "security"]
 requires-python = ">=3.13"
 dependencies = ["proxy-py>=2.4.10", "pyyaml>=6.0.3", "requests>=2.32.4"]
-version = "v0.0.18"
+version = "v0.0.19"
 
 # Presence enables setuptools-scm
 [tool.setuptools_scm]

--- a/uv.lock
+++ b/uv.lock
@@ -141,7 +141,7 @@ wheels = [
 
 [[package]]
 name = "github-standards"
-version = "0.0.18"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "proxy-py" },


### PR DESCRIPTION
Convert the personal data scan to output a message instead of running the docker image. This is to speed up the git hooks lifecycle