### PR TITLE
feature/convert-run-scan-to-a-placeholder-for-multiple-scans

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     branches: ["main"]
 
 jobs:
-  run-version-test:
+  verify-version:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,7 +24,7 @@ jobs:
           pip install pyyaml
           python3 -m src.actions.compare_versions
 
-  run-tests:
+  project-tests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
-  run-docker-verification:
+  docker-tests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,3 +76,70 @@ jobs:
         run: |
           echo 'Test commit message' >> COMMIT.txt
           docker run --user $(id -u):$(id -g) -v .:/source:rw,Z -w /source github-standards-hooks:verification-testing validate_scan --verbose COMMIT.txt
+
+  git-hooks-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Build docker image
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          push: false
+          build-args: TRUFFLEHOG_VERSION=${{ vars.TRUFFLEHOG_VERSION }}
+          tags: github-standards-hooks:verification-testing
+          target: testing
+
+      - name: Create pre_commit.yaml file
+        run: |
+          cat <<EOF > .local_hooks.yaml
+          repos:
+            - repo: local
+              hooks:
+                - id: run-security-scan
+                  name: run-security-scan
+                  language: docker_image
+                  entry: github-standards-hooks:verification-testing run_scan --verbose
+                  stages: [pre-commit]
+                  verbose: true
+                  require_serial: true
+
+                - id: run-personal-data-scan
+                  name: run-personal-data-scan
+                  language: docker_image
+                  entry: github-standards-hooks:verification-testing run_personal_data_scan --verbose
+                  stages: [pre-commit]
+                  verbose: true
+                  require_serial: true
+
+                - id: validate-security-scan
+                  name: validate-security-scan
+                  language: docker_image
+                  entry: github-standards-hooks:verification-testing validate_scan --verbose
+                  stages: [commit-msg]
+                  verbose: true
+          EOF
+
+      - name: Test pre-commit runs on example git repo
+        run: |
+          git -c init.defaultBranch=main init test_repo
+          git config --global user.email "ci_test@businessandtrade.gov.uk"
+          git config --global user.name "CI Test"
+
+          cp .gitignore test_repo/.gitignore
+          cp .local_hooks.yaml test_repo/.pre-commit-config.yaml
+
+          cd test_repo
+          python3 -m venv .venv
+          source .venv/bin/activate
+
+          pip install pre-commit
+          pre-commit install --install-hooks --overwrite -t commit-msg -t pre-commit
+          pre-commit autoupdate
+
+          git add .
+          git commit -m 'testing pre-commit hooks'

--- a/src/hooks/cli.py
+++ b/src/hooks/cli.py
@@ -7,7 +7,6 @@ from logging import StreamHandler, captureWarnings, INFO, DEBUG, Formatter
 from src.hooks.config import LOGGER
 from src.hooks.run_personal_data_scan import RunPersonalDataScan
 from src.hooks.run_security_scan import RunSecurityScan
-from src.hooks.trufflehog.vendors import AllowedTrufflehogVendor
 from src.hooks.validate_security_scan import ValidateSecurityScan
 
 from src.hooks.hooks_base import Hook
@@ -49,11 +48,7 @@ def parse_args(argv):
         help="Run this hook in a github action",
         required=False,
     )
-    run_scan_parser.set_defaults(
-        hook=lambda args: RunSecurityScan(
-            args.paths, args.verbose, args.github_action, allowed_vendor_endpoints=AllowedTrufflehogVendor.all_endpoints()
-        )
-    )
+    run_scan_parser.set_defaults(hook=lambda args: RunSecurityScan(args.paths, args.verbose, args.github_action))
 
     validate_scan_parser = subparsers.add_parser("validate_scan", parents=[parent_parser])
     validate_scan_parser.set_defaults(hook=lambda args: ValidateSecurityScan(args.paths, args.verbose))

--- a/src/hooks/trufflehog/scanner.py
+++ b/src/hooks/trufflehog/scanner.py
@@ -1,14 +1,19 @@
 import os
 import subprocess
 
+from proxy import Proxy
 from typing import List
 
+
 from src.hooks.config import (
+    DEFAULT_PROXY_DIRECTORY,
     LOGGER,
+    TRUFFLEHOG_PROXY,
     TRUFFLEHOG_INFO_LOG_LEVEL,
     TRUFFLEHOG_SUCCESS_CODE,
     TRUFFLEHOG_VERBOSE_LOG_LEVEL,
 )
+from src.proxy.plugins import OutgoingRequestInterceptorPlugin
 
 logger = LOGGER
 
@@ -17,26 +22,27 @@ class TrufflehogScanner:
     def __init__(
         self,
         verbose: bool = False,
-        github_action: bool = False,
         paths: List[str] = [],
-        allowed_vendor_codes: List[str] = [],
     ) -> None:
         self.verbose = verbose
-        self.github_action = github_action
         self.paths = paths
-        self.allowed_vendor_codes = allowed_vendor_codes
 
-    def _get_args(self) -> List[str]:
+    def _get_args(
+        self,
+        paths: List[str],
+        github_action: bool = False,
+        allowed_vendor_codes: List[str] = [],
+    ) -> List[str]:
         trufflehog_log_level = TRUFFLEHOG_VERBOSE_LOG_LEVEL if self.verbose else TRUFFLEHOG_INFO_LOG_LEVEL
 
-        if self.github_action:
+        if github_action:
             # Scan all files in this branch
-            paths_to_scan = [f"file://{self.paths[0]}"]
+            paths_to_scan = [f"file://{paths[0]}"]
             scan_mode = "git"
         else:
             # Scan the files passed in
             scan_mode = "filesystem"
-            paths_to_scan = self.paths
+            paths_to_scan = paths
 
         trufflehog_cmd_args = [
             "trufflehog",
@@ -47,14 +53,14 @@ class TrufflehogScanner:
             f"--log-level={trufflehog_log_level}",
         ]
 
-        if self.github_action:
+        if github_action:
             trufflehog_cmd_args.append("--since-commit=main")
 
         if os.path.exists("trufflehog-excludes.txt"):
             logger.debug("This repo has an exclusions file, adding this file to the trufflehog runner")
             trufflehog_cmd_args.append("--exclude-paths=trufflehog-excludes.txt")
 
-        trufflehog_detectors = ",".join(self.allowed_vendor_codes)
+        trufflehog_detectors = ",".join(allowed_vendor_codes)
         logger.debug(
             "A subset of detectors have been configured, using these instead of running all detectors: %s",
             trufflehog_detectors,
@@ -67,24 +73,60 @@ class TrufflehogScanner:
 
         return trufflehog_cmd_args
 
-    def scan(self, env: dict[str, str] = {}):
-        args = self._get_args()
+    def _get_trufflehog_env_vars(self):
+        env = dict(os.environ)
+        env["HTTP_PROXY"] = TRUFFLEHOG_PROXY
+        env["HTTPS_PROXY"] = TRUFFLEHOG_PROXY
+        return env
 
-        trufflehog_run = subprocess.run(
-            args,
-            text=True,
-            capture_output=True,
-            shell=False,
-            check=False,  # We are manually checking the response code of the trufflehog scan, setting check=True will raise an exception
-            env=env,
-        )
+    def scan(
+        self,
+        github_action: bool = False,
+        allowed_vendor_endpoints: List[str] = [],
+        allowed_vendor_codes: List[str] = [],
+    ):
+        # A cyber condition has been applied to using trufflehog, where the endpoints called by the trufflehog scanner
+        # need to be monitored. We don't have that in place currently, so for now use proxy.py running locally and block
+        # any requests made by trufflehog that have not been explicitly allowed
 
-        trufflehog_response = trufflehog_run.stdout if trufflehog_run.stdout else trufflehog_run.stderr
-        logger.debug("Trufflehog returncode was '%s'", trufflehog_run.returncode)
+        logger.debug("Using the %s folder for storing proxy.py data", DEFAULT_PROXY_DIRECTORY)
+        with Proxy(
+            port=8899,
+            plugins=[OutgoingRequestInterceptorPlugin],
+            log_level="ERROR",
+            enable_events=False,
+            input_args=[
+                "--allowed-trufflehog-vendor-endpoints",
+                ",".join(allowed_vendor_endpoints),
+                "--cache-dir",
+                f"{DEFAULT_PROXY_DIRECTORY}/cache",
+            ],
+            data_dir=DEFAULT_PROXY_DIRECTORY,
+            ca_cert_dir=f"{DEFAULT_PROXY_DIRECTORY}/certs",
+        ):
+            env = self._get_trufflehog_env_vars()
 
-        if trufflehog_run.returncode != TRUFFLEHOG_SUCCESS_CODE:
-            logger.debug("Trufflehog security scan failed with result: %s", trufflehog_response)
-            return trufflehog_response
+            args = self._get_args(
+                self.paths,
+                github_action,
+                allowed_vendor_codes,
+            )
 
-        logger.debug("Trufflehog security scan successfully completed with result: %s", trufflehog_response)
-        return None
+            trufflehog_run = subprocess.run(
+                args,
+                text=True,
+                capture_output=True,
+                shell=False,
+                check=False,  # We are manually checking the response code of the trufflehog scan, setting check=True will raise an exception
+                env=env,
+            )
+
+            trufflehog_response = trufflehog_run.stdout if trufflehog_run.stdout else trufflehog_run.stderr
+            logger.debug("Trufflehog returncode was '%s'", trufflehog_run.returncode)
+
+            if trufflehog_run.returncode != TRUFFLEHOG_SUCCESS_CODE:
+                logger.debug("Trufflehog security scan failed with result: %s", trufflehog_response)
+                return trufflehog_response
+
+            logger.debug("Trufflehog security scan successfully completed with result: %s", trufflehog_response)
+            return None

--- a/tests/unit/hooks/trufflehog/test_scanner.py
+++ b/tests/unit/hooks/trufflehog/test_scanner.py
@@ -8,57 +8,73 @@ from src.hooks.trufflehog.scanner import TrufflehogScanner
 
 
 class TestTrufflehogScanner:
-    def test_with_verbose_true_uses_verbose_trufflehog_log_level(self):
-        assert f"--log-level={TRUFFLEHOG_VERBOSE_LOG_LEVEL}" in TrufflehogScanner(verbose=True)._get_args()
+    def test_get_args_with_verbose_true_uses_verbose_trufflehog_log_level(self):
+        assert f"--log-level={TRUFFLEHOG_VERBOSE_LOG_LEVEL}" in TrufflehogScanner(verbose=True)._get_args([])
 
-    def test_with_verbose_false_uses_info_trufflehog_log_level(self):
-        assert f"--log-level={TRUFFLEHOG_INFO_LOG_LEVEL}" in TrufflehogScanner(verbose=False)._get_args()
+    def test_get_args_with_verbose_false_uses_info_trufflehog_log_level(self):
+        assert f"--log-level={TRUFFLEHOG_INFO_LOG_LEVEL}" in TrufflehogScanner(verbose=False)._get_args([])
 
-    def test_without_exclusions_file_does_not_have_exclude_arg_for_trufflehog(self):
+    def test_get_args_without_exclusions_file_does_not_have_exclude_arg_for_trufflehog(self):
         with patch("src.hooks.trufflehog.scanner.os.path.exists") as mock_isfile:
             mock_isfile.return_value = False
-            assert "--exclude-paths=trufflehog-excludes.txt" not in TrufflehogScanner()._get_args()
+            assert "--exclude-paths=trufflehog-excludes.txt" not in TrufflehogScanner()._get_args([])
 
-    def test_with_exclusions_file_present_includes_exclude_arg_for_trufflehog(self):
+    def test_get_args_with_exclusions_file_present_includes_exclude_arg_for_trufflehog(self):
         with patch("src.hooks.trufflehog.scanner.os.path.exists") as mock_isfile:
             mock_isfile.return_value = True
-            assert "--exclude-paths=trufflehog-excludes.txt" in TrufflehogScanner()._get_args()
+            assert "--exclude-paths=trufflehog-excludes.txt" in TrufflehogScanner()._get_args([])
 
-    def test_with_github_action_true_uses_git_scanning_mode(self):
-        args = TrufflehogScanner(paths=["/folder1"], github_action=True)._get_args()
+    def test_get_args_with_github_action_true_uses_git_scanning_mode(self):
+        args = TrufflehogScanner()._get_args(paths=["/folder1"], github_action=True)
         assert "file:///folder1" in args
         assert "git" in args
 
-    def test_with_github_action_false_uses_filesystem_scanning_mode(self):
+    def test_get_args_with_github_action_false_uses_filesystem_scanning_mode(self):
         paths = ["1.txt", "2.txt", "3.txt"]
-        args = TrufflehogScanner(github_action=False, paths=paths)._get_args()
+        args = TrufflehogScanner()._get_args(paths=paths, github_action=False)
         assert "filesystem" in args
         for file in paths:
             assert file in args
 
-    def test_expected_vendor_codes_are_added_to_trufflehog_args(self):
-        assert "--include-detectors=A,B" in TrufflehogScanner(allowed_vendor_codes=["A", "B"])._get_args()
+    def test_get_args_expected_vendor_codes_are_added_to_trufflehog_args(self):
+        assert "--include-detectors=A,B" in TrufflehogScanner()._get_args([], allowed_vendor_codes=["A", "B"])
 
-    def test_all_args(self):
-        assert TrufflehogScanner()._get_args() == [
+    def test_get_args_returns_all_expected_args(self):
+        assert TrufflehogScanner()._get_args(
+            ["1.txt"],
+            allowed_vendor_codes=[
+                "a",
+                "b",
+                "c",
+            ],
+        ) == [
             "trufflehog",
             "filesystem",
             "--fail",
             "--no-update",
             "--results=verified,unknown",
             f"--log-level={TRUFFLEHOG_INFO_LOG_LEVEL}",
-            "--include-detectors=",
+            "--include-detectors=a,b,c",
+            "1.txt",
         ]
 
     def test_scan_with_trufflehog_error_code_returns_error_response(self, fp):
-        with patch.object(TrufflehogScanner, "_get_args") as mock_args:
+        with (
+            patch.object(TrufflehogScanner, "_get_args") as mock_args,
+            patch("src.hooks.trufflehog.scanner.Proxy"),
+            patch.object(TrufflehogScanner, "_get_trufflehog_env_vars") as mock_env,
+        ):
             mock_args.return_value = ["arg1", "arg2"]
+            mock_env.return_value = {"env_1": "true"}
+
             scanner = fp.register(
                 ["arg1", "arg2"],
                 stdout="Called the scanning tool",
                 returncode=TRUFFLEHOG_ERROR_CODE,
             )
-            result = TrufflehogScanner().scan({"env_1": "true"})
+
+            result = TrufflehogScanner().scan()
+
             assert result is not None
             assert scanner.was_called()
             assert scanner.calls[0].kwargs == {
@@ -70,13 +86,28 @@ class TestTrufflehogScanner:
             }
 
     def test_scan_with_trufflehog_success_returns_no_error_response(self, fp):
-        with patch.object(TrufflehogScanner, "_get_args") as mock_args:
+        with (
+            patch.object(TrufflehogScanner, "_get_args") as mock_args,
+            patch("src.hooks.trufflehog.scanner.Proxy"),
+            patch.object(TrufflehogScanner, "_get_trufflehog_env_vars") as mock_env,
+        ):
             mock_args.return_value = ["arg1", "arg2"]
+            mock_env.return_value = {"env_1": "true"}
+
             scanner = fp.register(
                 ["arg1", "arg2"],
                 stdout="Called the scanning tool",
                 returncode=0,
             )
-            result = TrufflehogScanner().scan({})
+
+            result = TrufflehogScanner().scan()
+
             assert result is None
             assert scanner.was_called()
+            assert scanner.calls[0].kwargs == {
+                "text": True,
+                "env": {"env_1": "true"},
+                "shell": False,
+                "stderr": -1,
+                "stdout": -1,
+            }


### PR DESCRIPTION
- Combine security and personal data scans into a single pre-commit hook to improve performance. Having these as 2 separate hooks is preferable, but the time taken to run the docker container means it makes more sense to run them in the same hook
- Add a new test that creates a new git repo, installs the pre-commit hooks and commits a file to run the pre-commit hooks