### PR TITLE
bugfix/revert-bandit-scanner

### DIFF
--- a/.github/workflows/org.python-ci.yml
+++ b/.github/workflows/org.python-ci.yml
@@ -6,35 +6,43 @@ on:
     branches: [main, master, dev]
 
 jobs:
-  security-vulnerability-scan:
-    # Bandit has it's own github action, however it always installs the latest version and doesn't allow version pinning
-    env:
-      python-version: "3.13.9"
-      bandit-version: "1.9.1"
+  python-specific-check:
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
-      actions: read
       contents: read
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
-        with:
-          python-version: ${{env.python-version}}
+      - name: Empty step
+        run: echo 'Python checks to be run here'
 
-      - name: Install Bandit
-        shell: bash
-        run: pip install 'bandit[sarif,toml]==${{env.bandit-version}}'
+  # security-vulnerability-scan:
+  #   # Bandit has it's own github action, however it always installs the latest version and doesn't allow version pinning
+  #   env:
+  #     python-version: "3.13.9"
+  #     bandit-version: "1.9.1"
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     security-events: write
+  #     actions: read
+  #     contents: read
+  #   steps:
+  #     - name: Set up Python
+  #       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+  #       with:
+  #         python-version: ${{env.python-version}}
 
-      - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+  #     - name: Install Bandit
+  #       shell: bash
+  #       run: pip install 'bandit[sarif,toml]==${{env.bandit-version}}'
 
-      - name: Run Bandit
-        shell: bash
-        run: |
-          bandit -r . --confidence-level=high --severity-level=high -f sarif -o results.sarif -x './.venv,./tests,./test' || true
+  #     - name: Checkout repository
+  #       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb
-        with:
-          sarif_file: results.sarif
+  #     - name: Run Bandit
+  #       shell: bash
+  #       run: |
+  #         bandit -r . --confidence-level=high --severity-level=high -f sarif -o results.sarif -x './.venv,./tests,./test' || true
+
+  #     - name: Upload SARIF file
+  #       uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb
+  #       with:
+  #         sarif_file: results.sarif


### PR DESCRIPTION
Revert bandit scanner while a fix is identified to stop the advanced security message always appearing on PRs, even when there are no issues