### PR TITLE
Improve vulnerability notification message

### DIFF
--- a/.github/actions/notify/vulnerability/action.yml
+++ b/.github/actions/notify/vulnerability/action.yml
@@ -4,7 +4,7 @@ description: "Notify PR creator if vulnerabilities are found"
 inputs:
   message:
     description: "Message to post on the PR"
-    default: "⚠️ Vulnerabilities detected"
+    default: "⚠️ Python Vulnerabilities detected"
     required: false
   token:
     description: "GitHub token or PAT"
@@ -23,41 +23,61 @@ runs:
         count=0
         critical=""
         high=""
-        medium=""
+        moderate=""
         low=""
         unknown=""
 
+        declare -A seen  # associative array to track unique IDs
+
         for f in "$AUDIT_DIR"/*.json; do
           if [ -f "$f" ]; then
-            c=$(jq '[.dependencies[].vulns[]?] | length' "$f")
-            count=$((count + c))
-
-            # Iterate over each vulnerability object from the JSON file
             while IFS= read -r vuln; do
-              # Extract the vulnerability ID (GHSA or CVE) and fix versions if available
               id=$(echo "$vuln" | jq -r '.id')
               fix=$(echo "$vuln" | jq -r '.fix_versions | join(", ")')
 
-              # Default values if we can't get severity
+              # Skip if we've already processed this ID
+              if [[ -n "${seen[$id]}" ]]; then
+                continue
+              fi
+              seen[$id]=1
+              count=$((count + 1))
+
               sev="UNKNOWN"
               band="UNKNOWN"
+              ghsa=""
 
               if [ -n "$id" ]; then
                 resp=$(curl -s "https://api.osv.dev/v1/vulns/$id")
 
-                # Get the simple severity band (CRITICAL, HIGH, MEDIUM, LOW)
+                # Try severity from database_specific
                 band=$(echo "$resp" | jq -r '.database_specific.severity // empty')
-                if [ -n "$band" ] && [ "$band" != "null" ]; then
-                  sev="$band"
+
+                # GHSA alias if present
+                ghsa=$(echo "$resp" | jq -r '.aliases[]? | select(startswith("GHSA-"))' | head -n1)
+
+                # If severity missing, try GHSA alias
+                if [ -z "$band" ] || [ "$band" == "null" ]; then
+                  if [ -n "$ghsa" ]; then
+                    ghsa_resp=$(curl -s "https://api.osv.dev/v1/vulns/$ghsa")
+                    band=$(echo "$ghsa_resp" | jq -r '.database_specific.severity // empty')
+                  fi
                 fi
+
+                # Fall back to UNKNOWN if still empty
+                if [ -z "$band" ] || [ "$band" == "null" ]; then
+                  band="UNKNOWN"
+                fi
+
+                sev="$band"
               fi
 
-              line="- $id (fix: $fix, severity: $sev, band: $band)"
+              # Build line without score
+              line="- $id (fix: $fix, severity: $sev${ghsa:+, GHSA: $ghsa})"
 
               case "$band" in
                 CRITICAL) critical="$critical\n$line" ;;
                 HIGH)     high="$high\n$line" ;;
-                MEDIUM)   medium="$medium\n$line" ;;
+                MODERATE) moderate="$moderate\n$line" ;;
                 LOW)      low="$low\n$line" ;;
                 UNKNOWN|"") unknown="$unknown\n$line" ;;
               esac
@@ -68,7 +88,7 @@ runs:
         details=""
         [[ -n "$critical" ]] && details="$details\n**Critical:**$critical\n"
         [[ -n "$high"     ]] && details="$details\n**High:**$high\n"
-        [[ -n "$medium"   ]] && details="$details\n**Medium:**$medium\n"
+        [[ -n "$moderate" ]] && details="$details\n**Moderate:**$moderate\n"
         [[ -n "$low"      ]] && details="$details\n**Low:**$low\n"
         [[ -n "$unknown"  ]] && details="$details\n**Unknown (to be checked):**$unknown"
 
@@ -92,7 +112,7 @@ runs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `${message}: ${count} issues.\n\n${details}\n...\n\n`
+            body: `${message}: ${count} unique issues.\n\n${details}\n\n`
           })
       env:
         MESSAGE: ${{ inputs.message }}


### PR DESCRIPTION
***Improve vulnerability notification message***

Vulnerability scoring is messy because the same security vulnerability can have multiple IDs (like CVE, GHSA, or PYSEC), each coming from different databases. On top of that, severity scores (CVSS) can differ depending on who publishes them??!!, which makes it confusing to know how serious a vulnerability really is if we want to go with CVSS .

There have been discussions in the past from the pip-audit team, and updates can be tracked in the following issues:
- [Make more information available in the reports](https://github.com/pypa/pip-audit/issues/207#issuecomment-1625486518)
- [Get vulnerability score/severity with pip-audit](https://github.com/pypa/pip-audit/issues/654)

Since the audit has matured enough with the improvement/integration of the alias field, this can be resolved by them, but et’s see how it goes, as I would like to have pip-audit as a subcommand (pip audit) rather than just a library.
For now, we are iterating on aliases to solve the issue. Tested in this PR https://github.com/uktrade/security-vulnerability-check-poc/pull/5

Before
<img width="828" height="717" alt="Screenshot 2025-12-08 at 12 04 44" src="https://github.com/user-attachments/assets/3743d082-0a5f-4b92-ba5a-191a68c5f77b" />

After
<img width="887" height="831" alt="Screenshot 2025-12-08 at 12 04 54" src="https://github.com/user-attachments/assets/71f33666-f96b-41f2-8952-b77da31f39f6" />
