### PR TITLE
bugfix/errors-not-triggering-build-failures

### DIFF
--- a/src/hooks/cli.py
+++ b/src/hooks/cli.py
@@ -111,7 +111,7 @@ def main(argv: Optional[List[str]] = None):
     if not sys.argv:
         return 1
 
-    anyio.run(main_async, argv)
+    return anyio.run(main_async, argv)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Return the code of the scan to the main function so it can be passed to the sys.exit function. Without this, the job always passes even when a value was detected in the scans