### PR TITLE
feature/skip-vulnerability-for-private-repos

### DIFF
--- a/.github/workflows/org.python-ci.yml
+++ b/.github/workflows/org.python-ci.yml
@@ -57,6 +57,8 @@ jobs:
           sarif_file: ${{env.results-file}}
 
   vulnerability-scan:
+    # Checking for public, skipping private and internal
+    if: ${{ github.event.repository.visibility == 'public' }}
     env:
       audit-dir: "audit-reports"
     permissions:


### PR DESCRIPTION
Skip the python vulnerability scan if a repo is private or internall