### PR TITLE
bugfix/codeowners-formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
+  "files.associations": {
+    "CODEOWNERS*": "codeowners"
+  },
+  "[codeowners]": {
+    "editor.formatOnSave": false,
+  },
   "[python]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "charliermarsh.ruff"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
-- @uktrade/github-standards
+* @uktrade/github-standards
 
 # This config file contains the trufflehog vendors, and needs a review from a more specific list of users
 
-src/hooks/trufflehog/vendors.py @uktrade/github-standards-admin
+/src/hooks/trufflehog/vendors.py @uktrade/github-standards-admin


### PR DESCRIPTION
<!---
THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
--->

## What
Don't auto format the CODEOWNERS file in VS Code
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why
VS Code detects a CODEOWNERS file as markdown, and changes `*` to `-`
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [ ] I have tested locally
- [ ] Testing not required

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
