### PR TITLE
feature/remove-the-forced-update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,24 +6,6 @@ on:
     branches: ["main"]
 
 jobs:
-  verify-version:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
-
-      - name: Set up Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
-        with:
-          python-version-file: ".python-version"
-
-      - name: Compare project.toml version with pre-commit hooks
-        run: |
-          pip install pyyaml
-          python3 -m src.actions.compare_versions
-
   project-tests:
     runs-on: ubuntu-latest
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.13.1
+  rev: v0.14.10
   hooks:
     # Run the ruff linter and formatter using just command
     - id: ruff-check

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: Run a security scan
     description: Run a security scan against the files in this commit
     language: docker_image
-    entry: ghcr.io/uktrade/github-standards:v1.2.1 run_scan
+    entry: ghcr.io/uktrade/github-standards:latest run_scan
     stages: [pre-commit]
     require_serial: true # This avoids the pre-commit splitting the list of changed files into batches of 4, and calling the pre-commit hook multiple times
 
@@ -10,13 +10,13 @@
     name: Run a personal data scan
     description: Run a security scan against the files in this commit
     language: system
-    entry: bash -c 'echo "This hook is deprecated, it can be removed from your local .pre-commit-config.yaml file for version ghcr.io/uktrade/github-standards:v1.2.1" && exit 0'
+    entry: bash -c 'echo "This hook is deprecated, it can be removed from your local .pre-commit-config.yaml file for version ghcr.io/uktrade/github-standards:latest" && exit 0'
     stages: [pre-commit]
 
 -   id: validate-security-scan
     name: Validate the security scan hook
     description: Validate the hook that runs the security scans has run, and add a signed-off git trailer if security scans have passed
     language: docker_image
-    entry: ghcr.io/uktrade/github-standards:v1.2.1 validate_scan
+    entry: ghcr.io/uktrade/github-standards:latest validate_scan
     stages: [commit-msg]
 

--- a/src/hooks/hooks_base.py
+++ b/src/hooks/hooks_base.py
@@ -68,6 +68,7 @@ class Hook(ABC):
             if len(dbt_hook_repo) != 1:
                 logger.debug("File %s can only contain one github-standards repo entry", PRE_COMMIT_FILE)
                 return False
+
             return await self._validate_hook_settings(dbt_hook_repo[0])
 
     @abstractmethod

--- a/src/hooks/run_security_scan.py
+++ b/src/hooks/run_security_scan.py
@@ -114,15 +114,13 @@ class RunSecurityScan(Hook):
             version_in_remote = await self._get_version_from_remote()
 
             if version_in_config != version_in_remote:
-                logger.info(
+                logger.error(
                     "The version in your local config is %s, but the latest version is %s. Run `pre-commit autoupdate --repo https://github.com/uktrade/github-standards` to update to the latest version",
                     version_in_config,
                     version_in_remote,
                 )
-                return False
         except Exception:
             logger.exception("The remote version check failed", stack_info=True)
-            return True
 
         return True
 


### PR DESCRIPTION
<!---
THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
--->

## What
Remove the check in the pre-commit hook where the hooks fails if the local version differs from the latest. Instead log an error to the terminal but allow the commit. To ensure this doesn't leave repositories with out of date versions, switch to always use the `latest` docker tag when running the pre-commit hooks. This tag is updated as part of the release process, it is NOT updated on merges to main

This PR also removes the verify-version job from the test workflow, as this isn't needed with switching to using `latest`
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why
By enforcing this version check, every-time we release a new version we block repositories from making a commit until they first raise a PR to increase the pre-commit version. By switching to the using the latest docker tag, we can avoid this happening and they will simply pull the latest image the next time they run the pre-commit hook

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [x] I have tested locally
- [ ] Testing not required

## Reviewer Checklist

- [x] I have reviewed the PR and ensured no secret values are present
