### PR TITLE
feature/improve-test-job-speeds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,15 +28,19 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
-  docker-tests:
+  build-docker-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      image: ${{ steps.build.outputs.imageid }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
-        with:
-          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Build docker image
         id: build
@@ -46,11 +50,40 @@ jobs:
           build-args: TRUFFLEHOG_VERSION=${{ vars.TRUFFLEHOG_VERSION }}
           tags: github-standards-hooks:docker-tests
           target: testing
+          outputs: type=docker,dest=${{ runner.temp }}/myimage.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: myimage
+          path: ${{ runner.temp }}/myimage.tar
+          retention-days: 1
+
+  docker-tests:
+    needs: [build-docker-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          fetch-depth: 0
+
+      - name: Download artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          name: myimage
+          path: ${{ runner.temp }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/myimage.tar
 
       - name: Test run security scan
         run: |
           docker run --user $(id -u):$(id -g) -e FORCE_HOOK_CHECKS=0 --rm -v .:/src -w /src \
-          github-standards-hooks:docker-tests \
+          ${{ needs.build-docker-image.outputs.image }} \
           run_scan \
           --verbose \
           /src
@@ -58,7 +91,7 @@ jobs:
       - name: Test run security scan in github action mode
         run: |
           docker run --user $(id -u):$(id -g) -e FORCE_HOOK_CHECKS=0 --rm -v .:/src -w /src \
-          github-standards-hooks:docker-tests \
+          ${{ needs.build-docker-image.outputs.image }} \
           run_scan \
           --verbose \
           --github-action \
@@ -68,12 +101,13 @@ jobs:
         run: |
           echo 'Test commit message' >> COMMIT.txt
           docker run --user $(id -u):$(id -g) -e FORCE_HOOK_CHECKS=0 --rm -v .:/src -w /src \
-          github-standards-hooks:docker-tests \
+          ${{ needs.build-docker-image.outputs.image }} \
           validate_scan \
           --verbose \
           COMMIT.txt
 
   git-hooks-test:
+    needs: [build-docker-image]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -81,14 +115,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
-      - name: Build docker image
-        id: build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+      - name: Download artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
-          push: false
-          build-args: TRUFFLEHOG_VERSION=${{ vars.TRUFFLEHOG_VERSION }}
-          tags: github-standards-hooks:git-hooks-tests
-          target: testing
+          name: myimage
+          path: ${{ runner.temp }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/myimage.tar
 
       - name: Create pre_commit.yaml file
         run: |
@@ -99,7 +134,7 @@ jobs:
                 - id: run-security-scan
                   name: run-security-scan
                   language: docker_image
-                  entry: github-standards-hooks:git-hooks-tests run_scan --verbose
+                  entry: ${{ needs.build-docker-image.outputs.image }} run_scan --verbose
                   stages: [pre-commit]
                   verbose: true
                   require_serial: true                
@@ -107,7 +142,7 @@ jobs:
                 - id: validate-security-scan
                   name: validate-security-scan
                   language: docker_image
-                  entry: github-standards-hooks:git-hooks-tests validate_scan --verbose
+                  entry: ${{ needs.build-docker-image.outputs.image }} validate_scan --verbose
                   stages: [commit-msg]
                   verbose: true
           EOF


### PR DESCRIPTION
<!---
THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
--->

## What
Create a single job that builds the docker image used by test jobs. As jobs run on independant runner machines, it is not possible for the test jobs to directly access the build docker image from the build job. The upload and download artefact steps are used to get around this
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why
Both test jobs build their own image, which takes longer and adds duplicate code
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [ ] I have tested locally
- [ ] Testing not required

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
