### PR TITLE
bugfix/pull-latest-image-before-running

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: Run a security scan
     description: Run a security scan against the files in this commit
     language: docker_image
-    entry: ghcr.io/uktrade/github-standards:latest run_scan
+    entry: --pull always ghcr.io/uktrade/github-standards:latest run_scan
     stages: [pre-commit]
     require_serial: true # This avoids the pre-commit splitting the list of changed files into batches of 4, and calling the pre-commit hook multiple times
 
@@ -17,6 +17,6 @@
     name: Validate the security scan hook
     description: Validate the hook that runs the security scans has run, and add a signed-off git trailer if security scans have passed
     language: docker_image
-    entry: ghcr.io/uktrade/github-standards:latest validate_scan
+    entry: --pull always ghcr.io/uktrade/github-standards:latest validate_scan
     stages: [commit-msg]
 


### PR DESCRIPTION
# Description

When running the pre-commit hook on a developer machine, if the `:latest` tag already exists locally then no attempt is made to check if it is the latest. This change adds a check to always attempt pulling the latest docker image before running the hook

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
