### PR TITLE
bugfix/dont-run-terraform-for-dependabot-pr

### DIFF
--- a/.github/workflows/org.terraform-ci.yml
+++ b/.github/workflows/org.terraform-ci.yml
@@ -21,8 +21,10 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
     branches: [main, master, dev]
+
 jobs:
   terraform-ci:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -96,7 +98,7 @@ jobs:
           git config --global --get-regexp '^url\..*\.insteadOf$' || true
       - name: Add SSH Key
         id: ssh-agent
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd  # v0.9.1
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: |
             ${{ secrets.TERRAFORM_CI_DUMMY_SSH }}
@@ -115,7 +117,8 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ github.workspace }}/.terraform.d/plugin-cache
-          key: tf-plugins-${{ runner.os }}-tf${{ steps.setup-tf.outputs.terraform_version
+          key:
+            tf-plugins-${{ runner.os }}-tf${{ steps.setup-tf.outputs.terraform_version
             }}-${{ hashFiles('**/.terraform.lock.hcl') }}
           restore-keys: |
             tf-plugins-${{ runner.os }}-tf${{ steps.setup-tf.outputs.terraform_version }}-


### PR DESCRIPTION
# Description

PRs raised by dependabot fail due to their inability to access repo secrets. There is no way to make this work, so exclude the PR from running the terraform checks

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
