### PR TITLE
bugfix/dont-run-dependency-scan-on-dependabot-PR

### DIFF
--- a/.github/workflows/org.python-ci.yml
+++ b/.github/workflows/org.python-ci.yml
@@ -57,6 +57,8 @@ jobs:
           sarif_file: ${{env.results-file}}
 
   dependency-review:
+    # This job will fail on a push as it needs to do a diff as part of a PR
+    if: ${{ github.event_name == 'pull_request' }}
     permissions:
       pull-requests: write
       contents: read


### PR DESCRIPTION
# Description

Running the dependency-review action on a push event will always fail as it can only be run on a PR event. This happens in the event the `.github/workflows/org.python-ci.yml` is changed

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
