### PR TITLE
feature/revert-include-all-file-types-in-personal-data-scan

### DIFF
--- a/src/hooks/config.py
+++ b/src/hooks/config.py
@@ -31,6 +31,7 @@ DEFAULT_LANGUAGE_CODE = "en"
 ENGINE_CONFIG_FILE = "engine_config.yaml"
 NLP_CONFIG_FILE = "nlp_config.yaml"
 RECOGNIZER_CONFIG_FILE = "recognizer_config.yaml"
+DEFAULT_FILE_TYPES = [".txt", ".yml", ".yaml", ".csv"]
 EXCLUDED_PERSONAL_DATA_FILE_TYPES = [
     # fonts
     ".otf",

--- a/src/hooks/presidio/path_filter.py
+++ b/src/hooks/presidio/path_filter.py
@@ -6,7 +6,7 @@ from typing import List
 
 
 from src.hooks.config import (
-    EXCLUDED_PERSONAL_DATA_FILE_TYPES,
+    DEFAULT_FILE_TYPES,
     LOGGER,
 )
 
@@ -47,11 +47,11 @@ class PathFilter:
             return PathScanStatus.SKIPPED
 
         file_extension = Path(path).suffix
-        if file_extension in EXCLUDED_PERSONAL_DATA_FILE_TYPES:
+        if file_extension not in DEFAULT_FILE_TYPES:
             logger.debug(
                 "Path %s has an extension that is not accepted for scanning. The allowed paths are %s",
                 path,
-                EXCLUDED_PERSONAL_DATA_FILE_TYPES,
+                DEFAULT_FILE_TYPES,
             )
             return PathScanStatus.SKIPPED
 

--- a/tests/integration/hooks/presidio/test_scanner.py
+++ b/tests/integration/hooks/presidio/test_scanner.py
@@ -120,7 +120,6 @@ class TestPresidioScanner:
                 "tests/test_data/personal_data.txt",
                 "tests/test_data/personal_data.yaml",
                 "tests/test_data/personal_data.yml",
-                "tests/test_data/personal_data.py",
             ]
         ),
     )
@@ -137,7 +136,7 @@ class TestPresidioScanner:
             files_to_skip = [
                 NamedTemporaryFileSync(
                     dir=td,
-                    suffix=".jpg",
+                    suffix=".pdf",
                     mode="w+t",
                     prefix=f"SKIPPED_FILE_{i}_",
                 )


### PR DESCRIPTION
# Description

Revert the PR #170 as it is causing issues with presidio 

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
